### PR TITLE
removing root reference in gulpfile that causes an createError when

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,6 @@ gulp.task('watch', function(){
 
 gulp.task('connect', function() {
   connect.server({
-    root: '.',
     livereload: true
   });
 });


### PR DESCRIPTION
using serve
